### PR TITLE
Implement EditorConfig for editing convenience

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*.yaml]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = false


### PR DESCRIPTION
This patch introduces EditorConfig <https://editorconfig.org/> rules for
YAML documents for all supported text editors.

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>